### PR TITLE
Possible double-close, resulting in "undefined" behaviour.

### DIFF
--- a/Rest.cpp
+++ b/Rest.cpp
@@ -13,7 +13,9 @@
 #include <unistd.h>
 
 #include <curl/curl.h>
+#if LIBCURL_VERSION_NUM < 0x071507
 #include <curl/types.h>
+#endif
 #include <curl/easy.h>
 
 using namespace std;

--- a/Rest.cpp
+++ b/Rest.cpp
@@ -240,9 +240,10 @@ string Rest::put(const string& url, const string& filename)
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
     curl_global_cleanup();
-    fclose(hd_src);
-    if (res == CURLE_OK)
+    if (res == CURLE_OK) {
+      fclose(hd_src);
       return tbuffer;
+    }
   }
   
   fclose(hd_src);


### PR DESCRIPTION
cppcheck has correctly identified a bug in `Rest.cpp`:

```
[Rest.cpp:246]: (error) Memory pointed to by 'hd_src' is freed twice.
```

Currently, if/when `res != CURLE_OK`, then `fclose` is called twice on `hd_src` - which, according to various sources results in undefined behaviour.

> Upon successful completion 0 is returned. Otherwise, **EOF** is returned and _errno_ is set to indicate the error. In either case any further access (including another call to **fclose**()) to the stream results in undefined behavior. &mdash; [fclose(3) - Linux man page](http://linux.die.net/man/3/fclose)

This pull request fixes that issue.

Cheers.
